### PR TITLE
Fix loading the default messages

### DIFF
--- a/src/main/scala/givers/i18n/SbtI18n.scala
+++ b/src/main/scala/givers/i18n/SbtI18n.scala
@@ -35,7 +35,7 @@ object SbtI18n extends AutoPlugin {
     serializer in i18n := VueI18nSerializer,
     excludeFilter in i18n := HiddenFileFilter || "_*",
     includeFilter in i18n := new SimpleFileFilter({ f => f.isFile && f.getCanonicalPath.startsWith((path in i18n).value.getCanonicalPath) }),
-    resourceManaged in i18n := webTarget.value / "vueI18n" / "main",
+    resourceManaged in i18n := webTarget.value / "i18n" / "main",
     managedResourceDirectories in Assets+= (resourceManaged in i18n in Assets).value,
     resourceGenerators in Assets += i18n in Assets,
     i18n in Assets := task.dependsOn(WebKeys.webModules in Assets).value
@@ -48,6 +48,9 @@ object SbtI18n extends AutoPlugin {
     val vueI18nReporter = (reporter in Assets).value
     val defaultLocaleValue = (defaultLocale in i18n).value
     val serializerValue = (serializer in i18n).value
+    val localePath = (path in i18n).value
+
+    val defaultLocaleFile = localePath / "messages"
 
     val sources = (sourceDir ** ((includeFilter in i18n in Assets).value -- (excludeFilter in i18n in Assets).value)).get
 
@@ -73,6 +76,7 @@ object SbtI18n extends AutoPlugin {
         targetDir,
         logger,
         defaultLocaleValue,
+        defaultLocaleFile,
         serializerValue
       )
 


### PR DESCRIPTION
When a message in, say, `messages.th` was changed, but the `messages` file (the default) wasn't changed. sbt's `syncIncremental` doesn't pass `messages` into the file list. Thus, the error occurred because we couldn't find the default `messages` file.

Here's the stacktrace: 

```
[error] java.lang.Exception: Unable to find messages or messages.en-GB (the default locale).
[error] 	at givers.i18n.Compiler.$anonfun$compile$5(Compiler.scala:72)
[error] 	at scala.Option.getOrElse(Option.scala:121)
[error] 	at givers.i18n.Compiler.compile(Compiler.scala:72)
[error] 	at givers.i18n.SbtI18n$.$anonfun$task$3(SbtI18n.scala:80)
[error] 	at com.typesafe.sbt.web.incremental.package$.syncIncremental(package.scala:228)
[error] 	at givers.i18n.SbtI18n$.$anonfun$task$1(SbtI18n.scala:130)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:44)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:39)
[error] 	at sbt.std.Transform$$anon$4.work(System.scala:66)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:263)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16)
[error] 	at sbt.Execute.work(Execute.scala:272)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:263)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:174)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[error] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[error] 	at java.lang.Thread.run(Thread.java:748)
[error] (Web-assets / i18n) java.lang.Exception: Unable to find messages or messages.en-GB (the default locale).
```

We fix it by loading `messages` separately.